### PR TITLE
#33278 fix(module,routes): on extendRoutes run cb function on excluded....

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra')
 const { generateSitemaps } = require('./generator')
 const logger = require('./logger')
 const { registerSitemaps } = require('./middleware')
-const { getStaticRoutes } = require('./routes')
+const { getStaticRoutes, getExcludedSitemapStaticRoutes } = require('./routes')
 
 module.exports = async function module(moduleOptions) {
   const nuxtInstance = this
@@ -29,11 +29,18 @@ module.exports = async function module(moduleOptions) {
   nuxtInstance.extendRoutes((routes) => {
     // Create a cache for static routes
     globalCache.staticRoutes = getStaticRoutes(routes)
+    globalCache.staticExcludedRoutes = getExcludedSitemapStaticRoutes(routes)
 
     // On run cmd "build"
     if (!nuxtInstance.options.dev) {
       // Save static routes
       fs.outputJsonSync(jsonStaticRoutesPath, globalCache.staticRoutes)
+      // This hook comes after build:templates and build:extendedRoutes
+      this.nuxt.hook('build:done', () => {
+        if (moduleOptions.excludedSitemapStaticRoutesCb) {
+          moduleOptions.excludedSitemapStaticRoutesCb(globalCache.staticExcludedRoutes)
+        }
+      })
     }
   })
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,7 +25,19 @@ function excludeRoutes(patterns, routes) {
  */
 function getStaticRoutes(router) {
   // Get all static routes and ignore dynamic routes
-  return flattenStaticRoutes(router).filter(({ url }) => !url.includes(':') && !url.includes('*')).filter(route => extractComponentOptions(route.component, COMPONENT_OPTIONS_BLOCK, COMPONENT_OPTIONS_KEY) !== false)
+  return flattenStaticRoutes(router)
+    .filter(({ url }) => !url.includes(':') && !url.includes('*'))
+    .filter(
+      (route) => extractComponentOptions(route.component, COMPONENT_OPTIONS_BLOCK, COMPONENT_OPTIONS_KEY) !== false
+    )
+}
+function getExcludedSitemapStaticRoutes(router) {
+  // Get all static routes and ignore dynamic routes that have sitemap:false
+  return flattenStaticRoutes(router)
+    .filter(({ url }) => !url.includes(':') && !url.includes('*'))
+    .filter(
+      (route) => extractComponentOptions(route.component, COMPONENT_OPTIONS_BLOCK, COMPONENT_OPTIONS_KEY) === false
+    )
 }
 
 /**
@@ -43,7 +55,7 @@ function flattenStaticRoutes(router, path = '', routes = []) {
       return
     }
 
-    const realPath = route.path.startsWith('/') ? route.path : path + route.path; // Convert absolute paths of children into absolute ones, and allow inheritance within their children
+    const realPath = route.path.startsWith('/') ? route.path : path + route.path // Convert absolute paths of children into absolute ones, and allow inheritance within their children
     // Nested routes
     if (route.children) {
       return flattenStaticRoutes(route.children, realPath + '/', routes)
@@ -56,4 +68,4 @@ function flattenStaticRoutes(router, path = '', routes = []) {
   return routes
 }
 
-module.exports = { excludeRoutes, getStaticRoutes }
+module.exports = { excludeRoutes, getStaticRoutes, getExcludedSitemapStaticRoutes }


### PR DESCRIPTION
Created a helper function that gets all of the routes that have sitemap:false,
Later when extending the site's static sites it is registering a callback function on nuxt build:done hook which takes the excluded routes and uses them on event.